### PR TITLE
Add C++/CLI custom types

### DIFF
--- a/docs/modularization.md
+++ b/docs/modularization.md
@@ -127,9 +127,20 @@ struct Record1
 };
 ```
 
-```
+```cpp
 // For C++ <-> C++/CLI
-// TODO
+public ref class Record1 {
+public:
+    // Record1 public properties
+internal:
+    using CppType = ::mylib::Record1;
+    using CsType = Record1^;
+
+    static CppType ToCpp(CsType cs) { return /* your magic here */; }
+    static CsType FromCpp(const CppType& cs) { return /* your magic here */; }
+private:
+    // Record1 properties' backing fields
+}
 ```
 
 For `interface` classes the `CppType` alias is expected to be a `std::shared_ptr<T>`.


### PR DESCRIPTION
It was surprisingly hard to write this small piece and I realized that:

- C++/CLI doesn't use Boxed types (I just reviewed and it wasn't really needed), and
- The `ToCpp` and `FromCpp` converters are defined in the same class as the type definition

One thing that seems confusing in that section is what kind of custom type are we talking about; the date example defines a custom Djinni type that converts between preexisting types in all languages, while the code examples define "handwritten" translators for a custom `Record1` type. That seems to be the kind of code that Djinni would generate rather than being handwritten.

Would you give me an example of a use case where handwriting those translations would be necessary? I'm afraid I might have missed something which could lead to wrong code example for C++/CLI. Thanks!